### PR TITLE
feat(core): add project scaffold, Bedrock client, and session management

### DIFF
--- a/koda/.gitignore
+++ b/koda/.gitignore
@@ -10,3 +10,10 @@ build/
 *.egg-info/
 .DS_Store
 *.log
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfplan
+.terraform.lock.hcl

--- a/koda/pyproject.toml
+++ b/koda/pyproject.toml
@@ -3,10 +3,51 @@ name = "koda"
 version = "0.1.0"
 description = "AI Companion for First-Generation Academics"
 requires-python = ">=3.11"
+license = {text = "MIT"}
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "unit: Unit tests (no AWS calls)",
+    "integration: Integration tests (requires AWS credentials)",
+]
 
 [tool.ruff]
 line-length = 100
 target-version = "py311"
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort
+    "N",    # pep8-naming
+    "UP",   # pyupgrade
+    "S",    # bandit security
+    "B",    # bugbear
+    "A",    # builtins shadowing
+    "C4",   # comprehensions
+    "DTZ",  # datetime timezone
+    "SIM",  # simplify
+    "RUF",  # ruff-specific
+]
+ignore = [
+    "S101",  # assert in tests OK
+    "E501",  # line length handled by formatter
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S101"]
+"scripts/**" = ["T201"]
+
+[tool.bandit]
+exclude_dirs = ["tests", "scripts"]
+skips = ["B101"]
+
+[tool.mypy]
+python_version = "3.11"
+warn_return_any = true
+warn_unused_configs = true
+ignore_missing_imports = true

--- a/koda/requirements.txt
+++ b/koda/requirements.txt
@@ -7,3 +7,5 @@ pydantic>=2.0.0
 structlog>=24.0.0
 pytest>=8.0.0
 pytest-asyncio>=0.24.0
+streamlit>=1.40.0
+requests>=2.31.0


### PR DESCRIPTION
- NovaClient wrapper for Converse API with timeout config (3600s)
- Support for Extended Thinking (LOW/MEDIUM/HIGH)
- Built-in Code Interpreter and Web Grounding helpers
- Ephemeral conversation state with auto-expiry
- Anti-shame filter and intersectionality context enrichment
- Central config with settings for models, regions, and inference defaults
- Architecture documentation