### PR TITLE
test: add placeholder integration tests

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for KODA."""

--- a/tests/integration/test_placeholder.py
+++ b/tests/integration/test_placeholder.py
@@ -1,0 +1,12 @@
+"""Placeholder integration tests."""
+
+import pytest
+
+
+@pytest.mark.integration
+class TestIntegrationPlaceholder:
+    """Placeholder integration test class."""
+
+    def test_placeholder(self):
+        """Placeholder test - replace with real integration tests."""
+        assert True


### PR DESCRIPTION
- Add __init__.py to tests/integration/
- Add placeholder test file to prevent CI failures
- Allows pytest to find tests/integration/ directory
- Placeholder can be replaced with real integration tests later