### PR TITLE
fix: correct Nova 2 parameter validation for extended thinking modes

### DIFF
--- a/scripts/verify_setup.py
+++ b/scripts/verify_setup.py
@@ -1,9 +1,11 @@
 """Verify AWS Bedrock access and all Nova 2 Lite features."""
 
 import sys
+
 sys.path.insert(0, ".")
 
 from src.core.client import NovaClient
+
 
 def main():
     print("=" * 50)
@@ -21,14 +23,20 @@ def main():
     print("\n2. Extended Thinking (LOW)...")
     r = client.converse(
         messages=[{"role": "user", "content": [{"text": "What is BAföG in one sentence?"}]}],
-        reasoning_effort="low", max_tokens=200,
+        reasoning_effort="low",
+        max_tokens=200,
     )
     print(f"   ✓ {client.extract_text(r)[:80]}")
 
     print("\n3. Extended Thinking (HIGH)...")
     r = client.converse(
-        messages=[{"role": "user", "content": [{"text": "Explain the hidden curriculum concept in 2 sentences."}]}],
-        reasoning_effort="high", max_tokens=300,
+        messages=[
+            {
+                "role": "user",
+                "content": [{"text": "Explain the hidden curriculum concept in 2 sentences."}],
+            }
+        ],
+        reasoning_effort="high",
     )
     print(f"   ✓ {client.extract_text(r)[:80]}")
 
@@ -47,6 +55,7 @@ def main():
     print("\n" + "=" * 50)
     print("✅ All 5 tests passed. KODA is ready to build!")
     print("=" * 50)
+
 
 if __name__ == "__main__":
     main()

--- a/src/core/client.py
+++ b/src/core/client.py
@@ -116,8 +116,14 @@ class NovaClient:
         kw: dict = {
             "modelId": self.model_id,
             "messages": messages,
-            "inferenceConfig": {"maxTokens": max_tokens, "temperature": temperature, "topP": top_p},
         }
+        # When using high reasoning effort, don't include inference config
+        if reasoning_effort != "high":
+            kw["inferenceConfig"] = {
+                "maxTokens": max_tokens,
+                "temperature": temperature,
+                "topP": top_p,
+            }
         if system_prompt:
             kw["system"] = [{"text": system_prompt}]
         if tool_config:


### PR DESCRIPTION
- Conditionally exclude inferenceConfig when using high reasoning effort
- Amazon Bedrock requires temperature, topP, and maxTokens to be unset for extended thinking HIGH
- Fixes ValidationException previously blocking high reasoning tests
- All 5 verification tests now pass successfully

Verification status:
- Basic text inference
- Extended Thinking (LOW)
- Extended Thinking (HIGH)
- Code Interpreter
- Web Grounding

Modified:
- src/core/client.py: Updated _build() method parameter handling
- scripts/verify_setup.py: Removed max_tokens parameter from high reasoning test
