### PR TITLE
fix(deploy): PYTHONPATH + CloudFront origin protocol

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,9 @@ RUN chown -R koda:koda /app
 # OWASP CSVS-2.1: Switch to non-root user
 USER koda
 
+# Ensure src/ and config/ are importable as top-level packages
+ENV PYTHONPATH=/app
+
 # Expose Streamlit default port
 EXPOSE 8501
 

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -15,7 +15,7 @@ resource "aws_cloudfront_distribution" "koda" {
     custom_origin_config {
       http_port              = 80
       https_port             = 443
-      origin_protocol_policy = "https-only"
+      origin_protocol_policy = "http-only" # ALB has no HTTPS listener yet; CloudFront handles TLS termination
       origin_ssl_protocols   = ["TLSv1.2"]
     }
   }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -54,3 +54,15 @@ output "env_file_content" {
     SESSION_TIMEOUT_MINUTES=30
   EOT
 }
+
+# ── Application Access ─────────────────────────────────
+
+output "alb_url" {
+  description = "ALB DNS name (internal, for CloudFront origin)"
+  value       = aws_lb.koda.dns_name
+}
+
+output "cloudfront_url" {
+  description = "CloudFront distribution domain name (public access point)"
+  value       = aws_cloudfront_distribution.koda.domain_name
+}


### PR DESCRIPTION
Fixes two issues blocking the live app:

**1. `ModuleNotFoundError: No module named 'src'`**
- Added `ENV PYTHONPATH=/app` to Dockerfile
- Streamlit runs from `/app` but Python couldn't find top-level `src/` or `config/` without this

**2. 504 Gateway Timeout from CloudFront**
- Changed `origin_protocol_policy` from `https-only` → `http-only`
- ALB only has HTTP:80 listener (no ACM cert); CloudFront was trying HTTPS:443 and timing out
- CloudFront still serves HTTPS to viewers via `redirect-to-https`

**3. Missing outputs**
- Added `cloudfront_url` and `alb_url` to `outputs.tf`