### PR TITLE
fix(frontend): render markdown in agent responses + fix UI language defaults

### DIFF
--- a/src/i18n/strings.py
+++ b/src/i18n/strings.py
@@ -14,11 +14,17 @@ STRINGS = {
         "welcome_body": "KODA is your AI companion for navigating higher education.\n\nNo question is too basic. Nobody explains this automatically.",
         "input_placeholder": "Ask KODA anything about studying, finances, or university life...",
         "quick_bafoeg": "💰 What is BAföG?",
+        "quick_bafoeg_msg": "What is BAföG and how do I apply for it?",
         "quick_study": "🎓 Study or apprenticeship?",
+        "quick_study_msg": "How do I decide between university and a vocational apprenticeship?",
         "quick_overwhelmed": "😟 I feel overwhelmed",
+        "quick_overwhelmed_msg": "I feel overwhelmed and don't know where to start with university.",
         "quick_ects": "📖 What is ECTS?",
+        "quick_ects_msg": "What does ECTS mean and how do credit points work at university?",
         "quick_scholarships": "🔍 Find scholarships",
+        "quick_scholarships_msg": "What scholarships are available for first-generation students in Germany?",
         "quick_rolemodels": "⭐ Role models",
+        "quick_rolemodels_msg": "Can you show me role models who were the first in their family to study?",
         "thinking": "KODA is thinking...",
         "crisis_banner": "I notice you may be going through a difficult time. Here are immediate resources:",
         "footer": "KODA provides orientation, not legal or financial advice.\n\nNo data is stored. Your session is private and ephemeral.",
@@ -32,11 +38,17 @@ STRINGS = {
         "welcome_body": "KODA ist dein KI-Begleiter für den Weg ins Studium.\n\nKeine Frage ist zu einfach. Niemand erklärt das automatisch.",
         "input_placeholder": "Frag KODA alles über Studium, Finanzierung oder Uni-Leben...",
         "quick_bafoeg": "💰 Was ist BAföG?",
+        "quick_bafoeg_msg": "Was ist BAföG und wie beantrage ich es?",
         "quick_study": "🎓 Studium oder Ausbildung?",
+        "quick_study_msg": "Wie entscheide ich mich zwischen Studium und Ausbildung?",
         "quick_overwhelmed": "😟 Ich fühle mich überfordert",
+        "quick_overwhelmed_msg": "Ich fühle mich überfordert und weiß nicht, wo ich anfangen soll.",
         "quick_ects": "📖 Was bedeutet ECTS?",
+        "quick_ects_msg": "Was bedeutet ECTS und wie funktionieren Leistungspunkte an der Uni?",
         "quick_scholarships": "🔍 Stipendien finden",
+        "quick_scholarships_msg": "Welche Stipendien gibt es für Studierende aus Nicht-Akademikerfamilien?",
         "quick_rolemodels": "⭐ Vorbilder",
+        "quick_rolemodels_msg": "Zeig mir Vorbilder, die als Erste in ihrer Familie studiert haben.",
         "thinking": "KODA denkt nach...",
         "crisis_banner": "Ich merke, dass es dir gerade nicht gut geht. Hier sind sofortige Anlaufstellen:",
         "footer": "KODA bietet Orientierung, keine Rechts- oder Finanzberatung.\n\nEs werden keine Daten gespeichert. Deine Sitzung ist privat.",
@@ -45,7 +57,8 @@ STRINGS = {
 }
 
 
-DEFAULT_LANGUAGE = "en"
+# Default matches the pill pre-selection in the Streamlit UI ("🇩🇪 Deutsch")
+DEFAULT_LANGUAGE = "de"
 SUPPORTED_LANGUAGES = ["en", "de"]
 
 AGENT_LABELS = {


### PR DESCRIPTION
- Replace html.escape() + <br> rendering with st.chat_message() so that all markdown formatting (headers, bold, lists, code blocks) from agent responses is properly rendered in the chat interface on CloudFront.
- Rename _safe() to _safe_user() which is used only for user-supplied plain-text bubbles where markdown should not be processed.
- Pass ui_lang to get_response() so the crisis banner respects the language toggle instead of always defaulting to English.
- Fix DEFAULT_LANGUAGE from 'en' to 'de' to match the pre-selected Deutsch pill in the Streamlit UI (was causing a mismatch on first load).
- Add all quick_*_msg translation keys that were referenced in app.py but missing from i18n/strings.py (would have produced key-not-found fallback text in production).