### PR TITLE
fix(api): restrict CORS from wildcard to configurable origin allowlist

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -7,6 +7,7 @@ Model IDs follow the Nova 2 Developer Guide naming convention:
 """
 
 import os
+
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -27,9 +28,16 @@ DEFAULT_TEMPERATURE: float = 0.7
 DEFAULT_TOP_P: float = 0.9
 
 # ── Extended thinking effort levels ────────────────────
-REASONING_LOW: str = "low"        # Router, Crisis Radar, Compass
+REASONING_LOW: str = "low"  # Router, Crisis Radar, Compass
 REASONING_MEDIUM: str = "medium"
-REASONING_HIGH: str = "high"      # All domain agents
+REASONING_HIGH: str = "high"  # All domain agents
+
+# ── API security ──────────────────────────────────────
+# Comma-separated list of origins allowed to call the API.
+# OWASP A05:2021 — never use a wildcard '*' in production.
+# Example: https://koda.example.com,https://koda-staging.example.com
+_raw_origins: str = os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:8501")
+CORS_ALLOWED_ORIGINS: list[str] = [o.strip() for o in _raw_origins.split(",") if o.strip()]
 
 # ── Session ────────────────────────────────────────────
 SESSION_TIMEOUT_MINUTES: int = int(os.getenv("SESSION_TIMEOUT_MINUTES", "30"))

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -5,6 +5,7 @@ Flow: User message → Router (triage) + Crisis Radar (parallel) → Domain Agen
 Sessions are ephemeral. No persistent user data.
 """
 
+from config.settings import CORS_ALLOWED_ORIGINS
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
@@ -27,9 +28,12 @@ app = FastAPI(
 )
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_methods=["*"],
-    allow_headers=["*"],
+    # Origins are configured via the CORS_ALLOWED_ORIGINS environment variable.
+    # Default: localhost only. Override in production with the CloudFront domain.
+    # OWASP A05:2021 — a wildcard '*' is intentionally prohibited here.
+    allow_origins=CORS_ALLOWED_ORIGINS,
+    allow_methods=["POST", "DELETE", "GET"],
+    allow_headers=["Content-Type", "Authorization"],
 )
 
 # ── Agent registry ─────────────────────────────────


### PR DESCRIPTION
OWASP Top 10 A05:2021 Security Misconfiguration — using allow_origins=["*"] combined with allow_credentials or sensitive endpoints constitutes a misconfiguration that can allow cross-origin data exfiltration.

Changes:
  - config/settings.py: add CORS_ALLOWED_ORIGINS list, sourced from the CORS_ALLOWED_ORIGINS environment variable (comma-separated). Default for local development: http://localhost:8501 (Streamlit). Production override: set the env var to the CloudFront domain.
  - src/api/app.py: replace wildcard allow_origins/methods/headers with the explicit allowlist from settings. Only POST, DELETE, GET are permitted (the API has no PUT/PATCH endpoints).
  - Add explanatory OWASP comment so the intent is clear to future contributors and security reviewers.