### PR TITLE
fix(frontend): rerun after streaming so quick-actions and reset buton appear

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -853,6 +853,13 @@ if user_input:
         }
     )
 
+    # Rerun so the script executes top-to-bottom with the fully-updated
+    # message list.  Without this, _render_quick_actions() and the reset
+    # button were already committed to the page before the new messages
+    # were appended — making them invisible until the next user interaction
+    # (e.g. a language switch) happened to trigger its own st.rerun().
+    st.rerun()
+
 
 # ── Footer ─────────────────────────────────────────────
 


### PR DESCRIPTION
Streamlit executes script top-to-bottom on each run.  Before this fix, _render_quick_actions() and the reset button were evaluated before the message-append calls at bottom of the input-handling block, so they always saw the *previous* message list:

  1. chat history loop        ← old messages
  2. _render_quick_actions()  ← renders based on old state → invisible
  3. if messages: reset btn   ← False on first reply  → not shown
  4. st.chat_input()          ← captures new text
  5. messages.append(user)
  6. st.write_stream()        ← live streaming
  7. messages.append(assistant)
  8. script ends — no rerun

Result: buttons only appeared after the *next* unrelated interaction (e.g. switching language) that happened to trigger its own st.rerun().

Fix: call st.rerun() immediately after appending the assistant message. The stream has already completed and the full text is persisted in st.session_state.messages, so the rerun simply replays cleanly from state — chat history, quick-action buttons and reset button all render correctly in a single pass.