### PR TITLE
fix(ci): remove immutable latest tag push to ECR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,10 +55,6 @@ jobs:
           echo "Pushing to ECR..."
           docker push $IMAGE_URI
 
-          # Also tag as latest
-          docker tag $IMAGE_URI $ECR_REGISTRY/$ECR_REPOSITORY:latest
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
-
           echo "image-uri=$IMAGE_URI" >> "$GITHUB_OUTPUT"
           echo "✅ Image pushed: $IMAGE_URI" >> $GITHUB_STEP_SUMMARY
 


### PR DESCRIPTION
ECR repository has immutable tags enabled (supply chain security). The SHA-tagged image is sufficient for ECS deployments. Pushing :latest was redundant and fails with immutable tag policy.