### PR TITLE
fix(llm-prompt): remove leaked [HIDDEN] markers from model outputs

### DIFF
--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -177,6 +177,14 @@ class BaseAgent:
                 yield chunk
 
             full_text = "".join(collected)
+            # Safety-net: strip any [HIDDEN] markers that survived
+            # chunk-level filtering (e.g. split across two chunks).
+            from src.core.client import strip_hidden_markers
+
+            cleaned_text = strip_hidden_markers(full_text)
+            if cleaned_text != full_text:
+                full_text = cleaned_text
+
             if not full_text.strip():
                 logger.warning("empty_stream_response", agent=self.name)
                 yield self._fallback_message(messages)
@@ -186,7 +194,7 @@ class BaseAgent:
             # If the filter changes the text, re-yield the corrected version
             # as a single replacement chunk.
             filtered = apply_anti_shame_filter(full_text)
-            if filtered != full_text:
+            if filtered != full_text or full_text != "".join(collected):
                 # Signal to the caller that the streamed text should be
                 # replaced (Streamlit will overwrite the container).
                 yield "\x00REPLACE\x00" + filtered

--- a/src/core/client.py
+++ b/src/core/client.py
@@ -7,6 +7,7 @@ Includes retry logic with exponential backoff for transient errors.
 Reference: Nova 2 Developer Guide — "Core inference" and "Troubleshooting" chapters.
 """
 
+import re
 import time
 from collections.abc import Generator
 from typing import Any
@@ -32,6 +33,15 @@ logger = structlog.get_logger()
 # Retry configuration
 MAX_RETRIES = 3
 RETRY_BASE_DELAY = 1.0  # seconds
+
+_HIDDEN_RE = re.compile(r"\[HIDDEN\]")
+
+
+def strip_hidden_markers(text: str) -> str:
+    """Remove all ``[HIDDEN]`` reasoning markers leaked by the model."""
+    if "[HIDDEN]" not in text:
+        return text
+    return _HIDDEN_RE.sub("", text).strip()
 
 
 class NovaClientError(Exception):
@@ -111,13 +121,16 @@ class NovaClient:
         Yield text delta chunks from a converse_stream() response.
 
         Skips reasoning/thinking blocks — only yields the visible assistant text.
+        Strips leaked ``[HIDDEN]`` markers from each chunk.
         Suitable for passing directly to ``st.write_stream()``.
         """
         stream = stream_response.get("stream", stream_response)
         for event in stream:
             delta = event.get("contentBlockDelta", {}).get("delta", {})
             if "text" in delta:
-                yield delta["text"]
+                cleaned = strip_hidden_markers(delta["text"])
+                if cleaned:
+                    yield cleaned
 
     def with_code_interpreter(self, messages, system_prompt=None, reasoning_effort=None):
         """Converse using the built-in Code Interpreter system tool."""
@@ -146,8 +159,8 @@ class NovaClient:
                         parts.append(item["text"])
         text = "\n".join(parts) if parts else ""
         # Strip stray reasoning markers that leak into the visible text.
-        if text.startswith("[HIDDEN]"):
-            text = text[len("[HIDDEN]") :].lstrip()
+        # The model may emit one or many [HIDDEN] tags anywhere in the output.
+        text = strip_hidden_markers(text)
         # Web-grounding tool responses sometimes contain literal two-character
         # sequences "\n" instead of real newline characters.  Unescape them so
         # Streamlit (and st.markdown) render line breaks correctly.

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,9 +1,66 @@
 """Unit tests for Bedrock response parsing helpers."""
 
 import pytest
-from src.core.client import NovaClient
+from src.core.client import NovaClient, strip_hidden_markers
 
 pytestmark = pytest.mark.unit
+
+
+def _make_response(text: str) -> dict:
+    """Build a minimal Converse-style response containing *text*."""
+    return {"output": {"message": {"content": [{"text": text}]}}}
+
+
+class TestStripHiddenMarkers:
+    def test_no_markers(self):
+        assert strip_hidden_markers("Hello world") == "Hello world"
+
+    def test_single_prefix(self):
+        assert strip_hidden_markers("[HIDDEN]Hello") == "Hello"
+
+    def test_multiple_consecutive(self):
+        assert strip_hidden_markers("[HIDDEN][HIDDEN][HIDDEN]Hello") == "Hello"
+
+    def test_marker_in_middle(self):
+        assert strip_hidden_markers("Hello [HIDDEN] world") == "Hello  world"
+
+    def test_only_markers(self):
+        assert strip_hidden_markers("[HIDDEN][HIDDEN]") == ""
+
+    def test_empty_string(self):
+        assert strip_hidden_markers("") == ""
+
+
+class TestExtractTextHiddenMarkers:
+    def test_strips_single_prefix(self):
+        assert NovaClient.extract_text(_make_response("[HIDDEN]Hi")) == "Hi"
+
+    def test_strips_multiple_markers(self):
+        assert NovaClient.extract_text(_make_response("[HIDDEN][HIDDEN]Hi")) == "Hi"
+
+    def test_strips_marker_in_middle(self):
+        result = NovaClient.extract_text(_make_response("Start [HIDDEN] end"))
+        assert "[HIDDEN]" not in result
+
+    def test_clean_text_unchanged(self):
+        assert NovaClient.extract_text(_make_response("Just text")) == "Just text"
+
+
+class TestIterStreamTextHiddenMarkers:
+    def test_strips_hidden_from_chunks(self):
+        fake_stream = [
+            {"contentBlockDelta": {"delta": {"text": "[HIDDEN]"}}},
+            {"contentBlockDelta": {"delta": {"text": "Hello"}}},
+        ]
+        chunks = list(NovaClient.iter_stream_text({"stream": fake_stream}))
+        assert chunks == ["Hello"]
+
+    def test_strips_hidden_within_chunk(self):
+        fake_stream = [
+            {"contentBlockDelta": {"delta": {"text": "[HIDDEN]Hello [HIDDEN]world"}}},
+        ]
+        chunks = list(NovaClient.iter_stream_text({"stream": fake_stream}))
+        assert chunks == ["Hello world"]
 
 
 class TestWebCitationExtraction:


### PR DESCRIPTION
Add strip_hidden_markers utility and use it to remove all occurrences of [HIDDEN] from model responses. Strip markers in both streaming and non-streaming paths; apply chunk-level filtering and a safety-net on assembled streamed text (triggers REPLACE when needed). Add unit tests for hidden-marker handling and streaming behavior. All unit tests pass.

## What

<!-- Brief description of the change -->

## Why

<!-- Why is this change needed? -->

## Testing

- [x] Unit tests pass (`pytest tests/unit/`)
- [x] Manual testing done with Streamlit UI
- [x] Tested in both German and English

## Checklist

- [x] Code follows project conventions (ruff passes)
- [x] No secrets or credentials committed
- [x] Docstrings on all new public functions
- [x] ARCHITECTURE.md updated if architecture changed
